### PR TITLE
Host property is not always a ShadowDom host

### DIFF
--- a/src/querySelectorDeep.js
+++ b/src/querySelectorDeep.js
@@ -111,7 +111,7 @@ function findMatchingElement(splitSelector, possibleElementsIndex) {
 
 function findParentOrHost(element) {
     const parentNode = element.parentNode;
-    return parentNode && parentNode.host ? parentNode.host : parentNode === document ? null : parentNode;
+    return (parentNode && parentNode.host && parentNode.nodeType === 11) ? parentNode.host : parentNode === document ? null : parentNode;
 }
 
 /**


### PR DESCRIPTION
Got an issue I ran into that's a bit of an edge case, but wanted to report it.

Sometimes an element has a "host" property that isn't a ShadowDom host, and affects the `findParentOrHost()` method.

Github is the good example. Hopefully you can follow these repoducible steps:

1. Navigate to the [main Github page](https://github.com/Georgegriff/query-selector-shadow-dom) for your project.

1. Up top, where you have the tabs for _Code/Issues/Pull Requests/etc_, inspect the __<>__ icon next to _Code_.

1. You'll see there's an `svg.octicon` inside a `a.js-selected-navigation-item`. Select the __svg__ in the _Elements_ panel in the devtools.

1. Go to the devtools console and run `$0.parentNode.host` and you get _"github.com"_

Most of the anchors on the Github pages set the host property to _"github.com"_ and it breaks the `findParentOfHost()` method.

I changed the method to also make sure the parentNode is a __DocumentFragment__ node type, which solved things in my case.