### PR TITLE
Features/protractor locator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
+# IDEs
+.vscode
+.idea
+
+# Build artifacts
 node_modules
 dist
-.vscode
 coverage
 .DS_Store
 **/output/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 script:
   - mkdir -p dist
   - npm run test:ci
+  - npm run e2e:protractor
 after_success:
   - npm install -g codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ dist: xenial
 os: linux
 node_js:
   - "10"
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+services:
+  - xvfb
 sudo: required
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: node_js
+dist: xenial
+os: linux
 node_js:
   - "10"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-dist: trusty
 sudo: required
 addons:
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import { querySelectorAllDeep, querySelectorDeep } from 'query-selector-shadow-d
 
 Both of the methods above accept a 2nd parameter, see section `Provide alternative node`. This will change the starting element to search from i.e. it will find ancestors of that node that match the query.
 
-## Examples
+## Integrations
 
 ### CodeceptJS
 
@@ -48,6 +48,42 @@ const playwright = require('playwright');
 ```
 
 For a full example see: https://github.com/Georgegriff/query-selector-shadow-dom/blob/master/examples/playwright
+
+
+### Protractor
+
+This project provides a Protractor plugin, which can be enabled in your [`protractor.conf.js`](https://www.protractortest.org/#/api-overview) file:
+
+```javascript
+exports.config = {
+    plugins: [{
+        package: 'query-selector-shadow-dom/plugins/protractor'
+    }],
+    
+    // ... other Protractor-specific config
+};
+```
+
+The plugin registers a new [locator](https://www.protractortest.org/#/api?view=ProtractorBy) - `by.shadowDomCss(selector /* string */)`, which can be used in regular Protractor tests:
+
+```javascript
+element(by.shadowDomCss('#item-in-shadow-dom'))
+```
+
+The locator also works with [Serenity/JS](https://serenity-js.org) tests that [use Protractor](https://serenity-js.org/modules/protractor) under the hood:
+
+```typescript
+import 'query-selector-shadow-dom/plugins/protractor';
+import { Target } from '@serenity-js/protractor'
+import { by } from 'protractor';
+
+const ElementOfInterest = Target.the('element of interest')
+    .located(by.shadowDomCss('#item-in-shadow-dom'))
+```
+
+See the [end-to-end tests](https://github.com/Georgegriff/query-selector-shadow-dom/blob/features/protractor-locator/test/protractor-locator.e2e.js) for more examples.
+
+## Examples
 
 ### Provide alternative node
 ```javascript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "query-selector-shadow-dom",
-    "version": "0.4.6",
+    "version": "0.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -724,6 +724,38 @@
                 "webdriverio": "^5.15.2"
             }
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+            "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+            "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+            "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
+        },
+        "@testim/chrome-version": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
+            "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
+            "dev": true
+        },
         "@types/caseless": {
             "version": "0.12.2",
             "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -742,10 +774,32 @@
             "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
             "dev": true
         },
+        "@types/glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+            "dev": true,
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
+        },
         "@types/node": {
             "version": "10.12.10",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
             "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w==",
+            "dev": true
+        },
+        "@types/q": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+            "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
             "dev": true
         },
         "@types/request": {
@@ -760,11 +814,27 @@
                 "form-data": "^2.5.0"
             }
         },
+        "@types/selenium-webdriver": {
+            "version": "3.0.17",
+            "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.17.tgz",
+            "integrity": "sha512-tGomyEuzSC1H28y2zlW6XPCaDaXFaD6soTdb4GNdmte2qfHtrKqhy0ZFs4r/1hpazCfEZqeTSRLvSasmEx89uw==",
+            "dev": true
+        },
         "@types/tough-cookie": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
             "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==",
             "dev": true
+        },
+        "@types/yauzl": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+            "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@wdio/config": {
             "version": "5.22.4",
@@ -903,6 +973,12 @@
                 "negotiator": "0.6.1"
             }
         },
+        "adm-zip": {
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+            "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+            "dev": true
+        },
         "after": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -916,6 +992,24 @@
             "dev": true,
             "requires": {
                 "es6-promisify": "^5.0.0"
+            }
+        },
+        "aggregate-error": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+            "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "dependencies": {
+                "indent-string": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+                    "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+                    "dev": true
+                }
             }
         },
         "ajv": {
@@ -1152,6 +1246,21 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
             "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "^1.0.1"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
             "dev": true
         },
         "array-unique": {
@@ -1585,6 +1694,15 @@
             "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
             "dev": true
         },
+        "blocking-proxy": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/blocking-proxy/-/blocking-proxy-1.0.1.tgz",
+            "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0"
+            }
+        },
         "bluebird": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -1709,6 +1827,36 @@
                 "caniuse-lite": "^1.0.30000899",
                 "electron-to-chromium": "^1.3.82",
                 "node-releases": "^1.0.1"
+            }
+        },
+        "browserstack": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.6.0.tgz",
+            "integrity": "sha512-HJDJ0TSlmkwnt9RZ+v5gFpa1XZTBYTj0ywvLwJ3241J7vMw2jAsGNVhKHtmCOyg+VxeLZyaibO9UL71AsUeDIw==",
+            "dev": true,
+            "requires": {
+                "https-proxy-agent": "^2.2.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+                    "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^4.3.0",
+                        "debug": "^3.1.0"
+                    }
+                }
             }
         },
         "buffer": {
@@ -1868,6 +2016,173 @@
                 "upath": "^1.0.5"
             }
         },
+        "chromedriver": {
+            "version": "83.0.1",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-83.0.1.tgz",
+            "integrity": "sha512-51/YsLIMRF+L0ooMlM4aZjyoOpDs0gDXGlT6+/CwWEnvK53PUyef9FkotKbzknCaUeL/qUw3ic3IMmsNc+SUxg==",
+            "dev": true,
+            "requires": {
+                "@testim/chrome-version": "^1.0.7",
+                "axios": "^0.19.2",
+                "del": "^5.1.0",
+                "extract-zip": "^2.0.0",
+                "https-proxy-agent": "^2.2.4",
+                "mkdirp": "^1.0.4",
+                "tcp-port-used": "^1.0.1"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "del": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+                    "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+                    "dev": true,
+                    "requires": {
+                        "globby": "^10.0.1",
+                        "graceful-fs": "^4.2.2",
+                        "is-glob": "^4.0.1",
+                        "is-path-cwd": "^2.2.0",
+                        "is-path-inside": "^3.0.1",
+                        "p-map": "^3.0.0",
+                        "rimraf": "^3.0.0",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "extract-zip": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+                    "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yauzl": "^2.9.1",
+                        "debug": "^4.1.1",
+                        "get-stream": "^5.1.0",
+                        "yauzl": "^2.10.0"
+                    }
+                },
+                "fd-slicer": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+                    "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+                    "dev": true,
+                    "requires": {
+                        "pend": "~1.2.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "globby": {
+                    "version": "10.0.2",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+                    "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.0.3",
+                        "glob": "^7.1.3",
+                        "ignore": "^5.1.1",
+                        "merge2": "^1.2.3",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.4",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+                    "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+                    "dev": true
+                },
+                "https-proxy-agent": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+                    "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^4.3.0",
+                        "debug": "^3.1.0"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "3.2.6",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "^2.1.1"
+                            }
+                        }
+                    }
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-path-cwd": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+                    "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+                    "dev": true
+                },
+                "is-path-inside": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+                    "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "yauzl": {
+                    "version": "2.10.0",
+                    "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+                    "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+                    "dev": true,
+                    "requires": {
+                        "buffer-crc32": "~0.2.3",
+                        "fd-slicer": "~1.1.0"
+                    }
+                }
+            }
+        },
         "ci-info": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
@@ -1902,6 +2217,12 @@
                     }
                 }
             }
+        },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true
         },
         "cli-boxes": {
             "version": "1.0.0",
@@ -2518,6 +2839,21 @@
                 }
             }
         },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "dev": true,
+            "requires": {
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
+            }
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2550,6 +2886,23 @@
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
+        },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            },
+            "dependencies": {
+                "path-type": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
+                }
+            }
         },
         "dom-serialize": {
             "version": "2.2.1",
@@ -2891,6 +3244,12 @@
                 "strip-eof": "^1.0.0"
             }
         },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
         "expand-braces": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
@@ -3148,6 +3507,83 @@
             "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
             "dev": true
         },
+        "fast-glob": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+            "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+                    "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3159,6 +3595,15 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "fastq": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+            "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
         },
         "fd-slicer": {
             "version": "1.0.1",
@@ -4070,6 +4515,28 @@
             "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
             "dev": true
         },
+        "globby": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+            "dev": true,
+            "requires": {
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+            },
+            "dependencies": {
+                "arrify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                    "dev": true
+                }
+            }
+        },
         "got": {
             "version": "6.7.1",
             "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
@@ -4318,10 +4785,22 @@
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
             "dev": true
         },
+        "ignore": {
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+            "dev": true
+        },
         "ignore-by-default": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
             "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
+            "dev": true
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
             "dev": true
         },
         "import-lazy": {
@@ -4430,6 +4909,12 @@
             "requires": {
                 "loose-envify": "^1.0.0"
             }
+        },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+            "dev": true
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
@@ -4634,6 +5119,21 @@
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+            "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "^1.0.0"
+            }
+        },
         "is-path-inside": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -4712,6 +5212,12 @@
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
+        "is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+            "dev": true
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -4723,6 +5229,17 @@
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
+        },
+        "is2": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
+            "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
+            "dev": true,
+            "requires": {
+                "deep-is": "^0.1.3",
+                "ip-regex": "^2.1.0",
+                "is-url": "^1.2.2"
+            }
         },
         "isarray": {
             "version": "1.0.0",
@@ -4856,6 +5373,12 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.3.0.tgz",
             "integrity": "sha512-3/xSmG/d35hf80BEN66Y6g9Ca5l/Isdeg/j6zvbTYlTzeKinzmaTM4p9am5kYqOmE05D7s1t8FGjzdSnbUbceA==",
+            "dev": true
+        },
+        "jasminewd2": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-2.2.0.tgz",
+            "integrity": "sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=",
             "dev": true
         },
         "jest-worker": {
@@ -4997,6 +5520,18 @@
                 "verror": "1.10.0"
             }
         },
+        "jszip": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
+            "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+            "dev": true,
+            "requires": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
+            }
+        },
         "karma": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.1.tgz",
@@ -5125,6 +5660,15 @@
             "requires": {
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
+            }
+        },
+        "lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dev": true,
+            "requires": {
+                "immediate": "~3.0.5"
             }
         },
         "load-json-file": {
@@ -5393,6 +5937,12 @@
             "requires": {
                 "readable-stream": "^2.0.1"
             }
+        },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
         },
         "micromatch": {
             "version": "3.1.10",
@@ -5997,6 +6547,15 @@
                 "p-limit": "^2.0.0"
             }
         },
+        "p-map": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+            "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+            "dev": true,
+            "requires": {
+                "aggregate-error": "^3.0.0"
+            }
+        },
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -6014,6 +6573,12 @@
                 "registry-url": "^3.0.3",
                 "semver": "^5.1.0"
             }
+        },
+        "pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
         },
         "parse-function": {
             "version": "5.6.10",
@@ -6163,6 +6728,12 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
+        "picomatch": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "dev": true
+        },
         "pify": {
             "version": "2.3.0",
             "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -6185,33 +6756,46 @@
             }
         },
         "playwright": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.10.0.tgz",
-            "integrity": "sha512-f3VRME/PIO5NbcWnlCDfXwPC0DAZJ7ETkcAdE+sensLCOkfDtLh97E71ZuxNCaPYsUA6FIPi5syD8pHJW/4hQQ==",
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.12.1.tgz",
+            "integrity": "sha512-icF4+I8y7A5HjhbTsa4Eqtl2fuGe3ECvW0Wrn6aRM5eL5/AqUIgIf2U/0e1S1bEsDfz1JVvClGl5Gqw4aI5H4w==",
             "dev": true,
             "requires": {
-                "playwright-core": "=0.10.0"
+                "playwright-core": "=0.12.1"
             }
         },
         "playwright-core": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.10.0.tgz",
-            "integrity": "sha512-yernA6yrrBhmb8M5eO6GZsJOrBKWOZszlu65Luz8LP7ryaDExN1sE9XjQBNbiwJ5Gfs8cehtAO7GfTDJt+Z2cQ==",
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.12.1.tgz",
+            "integrity": "sha512-NZ8Qe/kqsgAmFBxWZnUeE+MoZ04UzNI0DHOKA+I1p/5rbpaWhe1Vx5zVNa05A1iEvOtnKV1PdIEe4IPumG2y2w==",
             "dev": true,
             "requires": {
                 "debug": "^4.1.0",
                 "extract-zip": "^1.6.6",
                 "https-proxy-agent": "^3.0.0",
                 "jpeg-js": "^0.3.6",
-                "mime": "^2.0.3",
                 "pngjs": "^3.4.0",
                 "progress": "^2.0.3",
-                "proxy-from-env": "^1.0.0",
-                "rimraf": "^2.6.1",
-                "uuid": "^3.4.0",
+                "proxy-from-env": "^1.1.0",
+                "rimraf": "^3.0.2",
                 "ws": "^6.1.0"
             },
             "dependencies": {
+                "proxy-from-env": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+                    "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
                 "ws": {
                     "version": "6.2.1",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -6287,6 +6871,297 @@
             "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
             "dev": true
         },
+        "protractor": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/protractor/-/protractor-7.0.0.tgz",
+            "integrity": "sha512-UqkFjivi4GcvUQYzqGYNe0mLzfn5jiLmO8w9nMhQoJRLhy2grJonpga2IWhI6yJO30LibWXJJtA4MOIZD2GgZw==",
+            "dev": true,
+            "requires": {
+                "@types/q": "^0.0.32",
+                "@types/selenium-webdriver": "^3.0.0",
+                "blocking-proxy": "^1.0.0",
+                "browserstack": "^1.5.1",
+                "chalk": "^1.1.3",
+                "glob": "^7.0.3",
+                "jasmine": "2.8.0",
+                "jasminewd2": "^2.1.0",
+                "q": "1.4.1",
+                "saucelabs": "^1.5.0",
+                "selenium-webdriver": "3.6.0",
+                "source-map-support": "~0.4.0",
+                "webdriver-js-extender": "2.1.0",
+                "webdriver-manager": "^12.1.7",
+                "yargs": "^15.3.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "cliui": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "jasmine": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+                    "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+                    "dev": true,
+                    "requires": {
+                        "exit": "^0.1.2",
+                        "glob": "^7.0.6",
+                        "jasmine-core": "~2.8.0"
+                    }
+                },
+                "jasmine-core": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+                    "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                },
+                "webdriver-manager": {
+                    "version": "12.1.7",
+                    "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-12.1.7.tgz",
+                    "integrity": "sha512-XINj6b8CYuUYC93SG3xPkxlyUc3IJbD6Vvo75CVGuG9uzsefDzWQrhz0Lq8vbPxtb4d63CZdYophF8k8Or/YiA==",
+                    "dev": true,
+                    "requires": {
+                        "adm-zip": "^0.4.9",
+                        "chalk": "^1.1.1",
+                        "del": "^2.2.0",
+                        "glob": "^7.0.3",
+                        "ini": "^1.3.4",
+                        "minimist": "^1.2.0",
+                        "q": "^1.4.1",
+                        "request": "^2.87.0",
+                        "rimraf": "^2.5.2",
+                        "semver": "^5.3.0",
+                        "xml2js": "^0.4.17"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                            "dev": true
+                        },
+                        "ansi-styles": {
+                            "version": "4.2.1",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                            "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                            "dev": true,
+                            "requires": {
+                                "@types/color-name": "^1.1.1",
+                                "color-convert": "^2.0.1"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "yargs": {
+                    "version": "15.4.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
         "proxy-from-env": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -6310,6 +7185,16 @@
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.2.tgz",
             "integrity": "sha512-vL6NLxNHzkNTjGJUpMm5PLC+94/0tTlC1vkP9bdU0pOHih+EujMjgMTwfZopZvHWRFbqJ5Y73OMoau50PewDDA==",
             "dev": true
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -6343,6 +7228,12 @@
                     }
                 }
             }
+        },
+        "q": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+            "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+            "dev": true
         },
         "qjobs": {
             "version": "1.2.0",
@@ -6721,6 +7612,12 @@
             "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
             "dev": true
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rfdc": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
@@ -6944,6 +7841,12 @@
                 "is-promise": "^2.1.0"
             }
         },
+        "run-parallel": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+            "dev": true
+        },
         "rxjs": {
             "version": "6.5.4",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
@@ -6973,6 +7876,65 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
+        },
+        "saucelabs": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.5.0.tgz",
+            "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
+            "dev": true,
+            "requires": {
+                "https-proxy-agent": "^2.2.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+                    "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+                    "dev": true,
+                    "requires": {
+                        "agent-base": "^4.3.0",
+                        "debug": "^3.1.0"
+                    }
+                }
+            }
+        },
+        "sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
+        },
+        "selenium-webdriver": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
+            "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
+            "dev": true,
+            "requires": {
+                "jszip": "^3.1.3",
+                "rimraf": "^2.5.4",
+                "tmp": "0.0.30",
+                "xml2js": "^0.4.17"
+            },
+            "dependencies": {
+                "tmp": {
+                    "version": "0.0.30",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.30.tgz",
+                    "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
+                    "dev": true,
+                    "requires": {
+                        "os-tmpdir": "~1.0.1"
+                    }
+                }
+            }
         },
         "semver": {
             "version": "5.6.0",
@@ -7008,6 +7970,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
             "dev": true
         },
         "set-value": {
@@ -7064,6 +8032,12 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
         "snapdragon": {
@@ -7315,6 +8289,15 @@
                 "resolve-url": "^0.2.1",
                 "source-map-url": "^0.4.0",
                 "urix": "^0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.5.6"
             }
         },
         "source-map-url": {
@@ -7570,6 +8553,16 @@
                         "util-deprecate": "^1.0.1"
                     }
                 }
+            }
+        },
+        "tcp-port-used": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
+            "integrity": "sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==",
+            "dev": true,
+            "requires": {
+                "debug": "4.1.0",
+                "is2": "2.0.1"
             }
         },
         "term-size": {
@@ -8064,6 +9057,16 @@
                 "request": "^2.83.0"
             }
         },
+        "webdriver-js-extender": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/webdriver-js-extender/-/webdriver-js-extender-2.1.0.tgz",
+            "integrity": "sha512-lcUKrjbBfCK6MNsh7xaY2UAUmZwe+/ib03AjVOpFobX4O7+83BUveSrLfU0Qsyb1DaKJdQRbuU+kM9aZ6QUhiQ==",
+            "dev": true,
+            "requires": {
+                "@types/selenium-webdriver": "^3.0.0",
+                "selenium-webdriver": "^3.0.1"
+            }
+        },
         "webdriverio": {
             "version": "5.22.4",
             "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-5.22.4.tgz",
@@ -8203,6 +9206,22 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
             "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
+        },
+        "xml2js": {
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "dev": true,
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            }
+        },
+        "xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "dev": true
         },
         "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "build": "rollup -c",
         "test": "karma start",
         "test:ci": "karma start --browsers ChromeHeadless,Firefox",
+        "e2e:protractor": "protractor protractor.conf.js",
         "watch": "npm-watch"
     },
     "watch": {
@@ -35,6 +36,7 @@
         "@babel/preset-env": "^7.1.0",
         "@webcomponents/webcomponentsjs": "^2.0.2",
         "babelrc-rollup": "^3.0.0",
+        "chromedriver": "^83.0.1",
         "codeceptjs": "^2.6.0",
         "jasmine": "^3.1.0",
         "karma": "^3.1.1",
@@ -46,6 +48,7 @@
         "karma-spec-reporter": "0.0.32",
         "npm-watch": "^0.4.0",
         "playwright": "^0.12.1",
+        "protractor": "^7.0.0",
         "puppeteer": "^2.0.0",
         "rollup": "^0.67.0",
         "rollup-plugin-babel": "^4.0.3",

--- a/plugins/protractor/index.d.ts
+++ b/plugins/protractor/index.d.ts
@@ -1,0 +1,13 @@
+declare module 'protractor' {
+    import { Locator } from 'protractor';
+
+    export interface ProtractorBy {
+        /**
+         * Find element within the Shadow DOM.
+         *
+         * @param {string} selector
+         * @returns {Locator} location strategy
+         */
+        shadowDomCss(selector: string): Locator;
+    }
+}

--- a/plugins/protractor/index.js
+++ b/plugins/protractor/index.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+const querySelectorAllDeep = fs.readFileSync(path.resolve(__dirname, "../../dist/querySelectorShadowDom.js"))
+
+module.exports = {
+    name: 'query-selector-shadow-dom',
+    onPrepare: function() {
+        global.by.addLocator('shadowDomCss', `
+            var selector /* string */ = arguments[0];
+            var parentElement /* WebElement? */ = arguments[1];
+            var rootSelector /* string? */ = arguments[2];
+            
+            ${ querySelectorAllDeep }
+
+            return querySelectorShadowDom.querySelectorAllDeep(selector, parentElement || document)
+        `);
+    }
+}

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,0 +1,37 @@
+exports.config = {
+    baseUrl: 'http://localhost:3000',
+
+    chromeDriver: require(`chromedriver/lib/chromedriver`).path,
+    SELENIUM_PROMISE_MANAGER: false,
+    directConnect: true,
+
+    // https://github.com/angular/protractor/blob/master/docs/timeouts.md
+    allScriptsTimeout: 110000,
+
+    specs: [ './test/protractor-locator.e2e.js', ],
+
+    plugins: [{
+        path: './plugins/protractor'
+    }],
+
+    onPrepare: function() {
+        global.browser.waitForAngularEnabled(false);
+    },
+
+    capabilities: {
+        browserName: 'chrome',
+
+        chromeOptions: {
+            args: [
+                '--no-sandbox',
+                '--disable-infobars',
+                '--disable-dev-shm-usage',
+                '--disable-extensions',
+                '--log-level=3',
+                '--disable-gpu',
+                '--window-size=1920,1080',
+                '--headless'
+            ]
+        }
+    }
+};

--- a/test/protractor-locator.e2e.js
+++ b/test/protractor-locator.e2e.js
@@ -1,0 +1,48 @@
+describe('query-selector-shadow-dom', () => {
+
+    beforeEach(async () => {
+        await browser.get(pageFromTemplate(`
+            var firstParent = document.createElement('div');
+            firstParent.id = 'first';
+            firstParent.classList.add('parent');            
+            document.body.appendChild(firstParent);
+            
+            var secondParent = document.createElement('div');
+            secondParent.classList.add('parent');            
+            document.body.appendChild(secondParent);
+            
+            var firstShadowChild = firstParent.attachShadow({ mode: 'open' });
+            firstShadowChild.innerHTML = '<p class="shadow-child"><span class="name">First child</span> with Shadow DOM</p>';        
+            
+            var secondShadowChild = secondParent.attachShadow({ mode: 'open' });
+            secondShadowChild.innerHTML = '<p class="shadow-child"><span class="name">Second child</span> with Shadow DOM</p>';
+        `));
+    });
+
+    it(`identifies a single element matching the selector`, async () => {
+        const text = await element(by.shadowDomCss('#first.parent .shadow-child .name')).getText();
+
+        expect(text).toEqual('First child');
+    });
+
+    it(`identifies all elements matching the selector`, async () => {
+        const text = await element.all(by.shadowDomCss('.parent .shadow-child .name')).getText();
+
+        expect(text).toEqual(['First child', 'Second child']);
+    });
+});
+
+/**
+ * Turns a HTML template into a data URL Protractor can navigate to without having to use a web server
+ *
+ * @param {string} template
+ * @returns {string}
+ */
+function pageFromTemplate(template /* string */) /* string */ {
+    return `data:text/html;charset=utf-8,<!DOCTYPE html>
+        <html>
+            <body>
+                <script>${ template }</script>
+            </body>
+        </html>`.replace(/[\s\n]+/s, ' ');
+}


### PR DESCRIPTION
Hi again, @Georgegriff !

I've prepared a simple Angular Protractor plugin that addresses #33 and should integrate nicely with [Serenity/JS](https://serenity-js.org) I'm the author of, and which uses Protractor under the hood.

So starting from the outside, a person using [Angular Protractor](https://github.com/angular/protractor) would need to configure their test runner in their `protractor.conf.js` to use the `query-selector-shadow-dom/plugins/protractor` [Protractor plugin](https://www.protractortest.org/#/plugins):

```javascript
    plugins: [{
        package: 'query-selector-shadow-dom/plugins/protractor'
    }],
```

You'll see this demonstrated in the end-to-end test I've added (see `test/protractor-locator.e2e.js` and `protractor.conf.js`)

The plugin (at `plugins/protractor/index.js`) follows a very similar pattern you've already established for Playwright.

Since both Serenity/JS and Protractor are written in [TypeScript](https://www.typescriptlang.org/) I've also added a `plugins/protractor/index.d.ts` file that describes the new method that the plugin registers on Protractor's [`by` object](https://www.protractortest.org/#/api?view=ProtractorBy.prototype.addLocator). 

There's a couple of things I wasn't sure of, so would appreciate your feedback on.

- I didn't notice e2e tests for Playwright or Codecept, so I've added the one for Protractor under `test/`. I'm not sure if you're happy with this location or if I should move that file somewhere else?
- I've added `npm run e2e:protractor` to the CI config too, but not to regular `npm test` since that might interfere with running Karma in watch mode.
- The way that e2e test generates shadow root components is a bit primitive since Protractor doesn't support pre-processors like Karma does and I couldn't re-use your test helpers.
- I've called the protractor locator `by.shadowDomCss`, which may or may not be the best name for it. I've considered `by.shadowCss` but that didn't seem correct (it's a shadow DOM, not a shadow CSS after all) and `by.querySelectorShadowDom`, but that seemed a bit wordy.
- I had to update Travis config to use Node 10, Xenial and an XVFB service to make it work with the latest chromedriver

If you find this PR too large or out of scope for this project please let me know and I can release it as a separate lib with a dependency on yours, I don't mind.

Looking forward to hearing your thoughts!

Jan