### PR TITLE
Cache collected elements and support ">" in selectors

### DIFF
--- a/src/querySelectorDeep.js
+++ b/src/querySelectorDeep.js
@@ -17,15 +17,15 @@
 * Another example querySelectorAllDeep('#downloads-list div#title-area + a');
 e.g.
 */
-export function querySelectorAllDeep(selector, root = document) {
-    return _querySelectorDeep(selector, true, root);
+export function querySelectorAllDeep(selector, root = document, allElements = null) {
+    return _querySelectorDeep(selector, true, root, allElements);
 }
 
-export function querySelectorDeep(selector, root = document) {
-    return _querySelectorDeep(selector, false, root);
+export function querySelectorDeep(selector, root = document, allElements = null) {
+    return _querySelectorDeep(selector, false, root, allElements);
 }
 
-function _querySelectorDeep(selector, findMany, root) {
+function _querySelectorDeep(selector, findMany, root, allElements = null) {
     selector = normalizeSelector(selector)
     let lightElement = root.querySelector(selector);
 
@@ -51,7 +51,7 @@ function _querySelectorDeep(selector, findMany, root) {
                 // filter out entry white selectors
                 .filter((entry) => !!entry);
             const possibleElementsIndex = splitSelector.length - 1;
-            const possibleElements = collectAllElementsDeep(splitSelector[possibleElementsIndex], root);
+            const possibleElements = collectAllElementsDeep(splitSelector[possibleElementsIndex], root, allElements);
             const findElements = findMatchingElement(splitSelector, possibleElementsIndex, root);
             if (findMany) {
                 acc = acc.concat(possibleElements.filter(findElements));
@@ -133,26 +133,29 @@ function findParentOrHost(element, root) {
  * @author ebidel@ (Eric Bidelman)
  * License Apache-2.0
  */
-function collectAllElementsDeep(selector = null, root) {
-    const allElements = [];
+export function collectAllElementsDeep(selector = null, root, _allElements = null) {
+    let allElements = [];
 
-    const findAllElements = function(nodes) {
-        for (let i = 0, el; el = nodes[i]; ++i) {
-            allElements.push(el);
-            // If the element has a shadow root, dig deeper.
-            if (el.shadowRoot) {
-                findAllElements(el.shadowRoot.querySelectorAll('*'));
+    if (_allElements) {
+        allElements = _allElements;
+    } else {
+        const findAllElements = function(nodes) {
+            for (let i = 0, el; el = nodes[i]; ++i) {
+                allElements.push(el);
+                // If the element has a shadow root, dig deeper.
+                if (el.shadowRoot) {
+                    findAllElements(el.shadowRoot.querySelectorAll('*'));
+                }
             }
         }
-    };
-    if(root.shadowRoot) {
-        findAllElements(root.shadowRoot.querySelectorAll('*'));
+        if(root.shadowRoot) {
+            findAllElements(root.shadowRoot.querySelectorAll('*'));
+        }
+        findAllElements(root.querySelectorAll('*'));
     }
-    findAllElements(root.querySelectorAll('*'));
 
     return selector ? allElements.filter(el => el.matches(selector)) : allElements;
 }
-
 
 // normalize-selector-rev-02.js
 /*

--- a/src/querySelectorDeep.js
+++ b/src/querySelectorDeep.js
@@ -153,11 +153,11 @@ function findParentOrHost(element, root) {
  * @author ebidel@ (Eric Bidelman)
  * License Apache-2.0
  */
-export function collectAllElementsDeep(selector = null, root, _allElements = null) {
+export function collectAllElementsDeep(selector = null, root, cachedElements = null) {
     let allElements = [];
 
-    if (_allElements) {
-        allElements = _allElements;
+    if (cachedElements) {
+        allElements = cachedElements;
     } else {
         const findAllElements = function(nodes) {
             for (let i = 0, el; el = nodes[i]; ++i) {

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -151,6 +151,7 @@ describe("Basic Suite", function() {
             testComponent.classList.add('container');
             const testComponents = querySelectorAllDeep(`.container > div > .header-2 > .find-me`);
             expect(testComponents.length).toEqual(1);
+            expect(testComponents[0].classList.contains('find-me')).toEqual(true);
         });
 
         it('can handle extra white space in selectors', function() {

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -1,4 +1,4 @@
-import { querySelectorAllDeep, querySelectorDeep } from '../src/querySelectorDeep.js';
+import { querySelectorAllDeep, querySelectorDeep, collectAllElementsDeep } from '../src/querySelectorDeep.js';
 import { createTestComponent, createNestedComponent, COMPONENT_NAME, createChildElements } from './createTestComponent.js';
 
 
@@ -31,6 +31,10 @@ describe("Basic Suite", function() {
 
     it("exports querySelectorDeep function", function() {
         expect(querySelectorDeep).toEqual(jasmine.any(Function));
+    });
+
+    it("exports collectAllElementsDeep function", function() {
+        expect(collectAllElementsDeep).toEqual(jasmine.any(Function));
     });
 
     it("querySelectorDeep returns null when not found", function() {
@@ -322,6 +326,35 @@ describe("Basic Suite", function() {
             const testComponent = querySelectorAllDeep('.inner-content', root);
             expect(testComponent.length).toEqual(1);
 
+        });
+
+        it('can cache collected elements with collectAllElementsDeep', function() {
+            const root = document.createElement('div');
+            parent.appendChild(root);
+
+            createTestComponent(root, {
+                childClassName: 'inner-content'
+            });
+
+            createTestComponent(parent, {
+                childClassName: 'inner-content'
+            });
+            const collectedElements = collectAllElementsDeep('', root)
+            expect(collectedElements.length).toEqual(4);
+
+            const testComponents = querySelectorAllDeep('.inner-content', root, collectedElements);
+            expect(testComponents.length).toEqual(1);
+
+            // remove element from dom
+            testComponents[0].remove()
+
+            // not found in dom
+            const testComponents2 = querySelectorAllDeep('.inner-content', root);
+            expect(testComponents2.length).toEqual(0);
+
+            // still there with cached collectedElements
+            const testComponents3 = querySelectorAllDeep('.inner-content', root, collectedElements);
+            expect(testComponents3.length).toEqual(1);
         });
 
         it('can query nodes in an iframe', function(done) {

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -138,6 +138,17 @@ describe("Basic Suite", function() {
             expect(testComponents.length).toEqual(1);
         });
 
+        it('can see inside the shadowRoot with ">" in selector', function() {
+            const testComponent = createTestComponent(parent, {
+                childClassName: 'header-1',
+                internalHTML: '<div class="header-2"><div class="find-me"></div></div>'
+            });
+            testComponent.shadowRoot.querySelector('.header-2').host = "test.com";
+            testComponent.classList.add('container');
+            const testComponents = querySelectorAllDeep(`.container > div > .header-2 > .find-me`);
+            expect(testComponents.length).toEqual(1);
+        });
+
         it('can handle extra white space in selectors', function() {
             const testComponent = createTestComponent(parent, {
                 childClassName: 'header-1',


### PR DESCRIPTION
This PR adds two features that I needed:

- It's now possible to select inside shadow roots when a selector has `">"` in it. E.g. `div > custom-element > div > div`. Previously each part with ">" was treated as one selector that was passed to `document.querySelectorAll("div>custom-element>div>div")`.

- I exported the `collectAllElementsDeep` function to speed up repetitive lookups.

I have added tests for both features.