### PR TITLE
Puppeteer registerCustomQueryHandler API

### DIFF
--- a/examples/puppeteer/clicking-elements.js
+++ b/examples/puppeteer/clicking-elements.js
@@ -2,7 +2,7 @@ const puppeteer = require('puppeteer');
 const {  QueryHandler } = require("query-selector-shadow-dom/plugins/puppeteer");
 (async () => {
     try {
-        await puppeteer.__experimental_registerCustomQueryHandler('shadow', QueryHandler);
+        await puppeteer.registerCustomQueryHandler('shadow', QueryHandler);
         const browser = await puppeteer.launch({
             headless: false,
             devtools: true

--- a/examples/puppeteer/custom-engine.js
+++ b/examples/puppeteer/custom-engine.js
@@ -2,7 +2,7 @@ const {  QueryHandler } = require("query-selector-shadow-dom/plugins/puppeteer")
 const puppeteer = require('puppeteer');
 
 const main = async () => {
-  await puppeteer.__experimental_registerCustomQueryHandler('shadow', QueryHandler);
+  await puppeteer.registerCustomQueryHandler('shadow', QueryHandler);
 
   const browser = await puppeteer.chromium.launch({ headless: false});
   const context = await browser.newContext({ viewport: null });

--- a/examples/puppeteer/multiple-elements.js
+++ b/examples/puppeteer/multiple-elements.js
@@ -2,7 +2,7 @@ const puppeteer = require('puppeteer');
 const {  QueryHandler } = require("query-selector-shadow-dom/plugins/puppeteer");
 (async () => {
     try {
-        await puppeteer.__experimental_registerCustomQueryHandler('shadow', QueryHandler);
+        await puppeteer.registerCustomQueryHandler('shadow', QueryHandler);
         const browser = await puppeteer.launch({
             headless: false
         })

--- a/examples/puppeteer/typing-to-elements.js
+++ b/examples/puppeteer/typing-to-elements.js
@@ -2,7 +2,7 @@ const puppeteer = require('puppeteer');
 const {  QueryHandler } = require("query-selector-shadow-dom/plugins/puppeteer");
 (async () => {
     try {
-        await puppeteer.__experimental_registerCustomQueryHandler('shadow', QueryHandler);
+        await puppeteer.registerCustomQueryHandler('shadow', QueryHandler);
         const browser = await puppeteer.launch({
             headless: false
         })


### PR DESCRIPTION
Since https://openbase.io/js/puppeteer-core/versions#5.4.0 , the registerCustomQueryHandler API is no longer experimental