### PR TITLE
Escape class names

### DIFF
--- a/src/querySelectorDeep.js
+++ b/src/querySelectorDeep.js
@@ -87,7 +87,7 @@ function findMatchingElement(splitSelector, possibleElementsIndex, root) {
         while (parent && !isDocumentNode(parent)) {
             let foundMatch = true;
             if (splitSelector[position].length === 1) {
-                foundMatch = parent.matches(splitSelector[position]);
+                foundMatch = parent.matches(splitSelector[position][0].split('.').reduce((acc, nextSelector) => acc + '.' + CSS.escape(nextSelector)));
             } else {
                 // selector is in the format "a > b"
                 // make sure a few parents match in order
@@ -177,5 +177,5 @@ export function collectAllElementsDeep(selector = null, root, cachedElements = n
         findAllElements(root.querySelectorAll('*'));
     }
 
-    return selector ? allElements.filter(el => el.matches(selector)) : allElements;	}
+    return selector ? allElements.filter(el => el.matches(selector.split('.').reduce((acc, nextSelector) => acc + '.' + CSS.escape(nextSelector)))) : allElements;	}
 


### PR DESCRIPTION
When an element has class names starting with number, the Element.matches is failing to identify the right element.

<div class="classA 2f683ff1c2173060crd67792e542ss17" ...></div>
Ex: div.classA.2f683ff1c2173060crd67792e542ss17

Expected: Should identify element with classA and 2f683ff1c2173060crd67792e542ss17 as classes
Actual: Element.matches throws Error as it is invalid id

@Georgegriff Let me know your thoughts on this